### PR TITLE
Fix/synthetic-outlet-rng

### DIFF
--- a/src/lsl_harness/fixtures/synthetic_outlet.py
+++ b/src/lsl_harness/fixtures/synthetic_outlet.py
@@ -127,7 +127,8 @@ def run_synthetic_outlet(
         )
 
         # 2. Simulate burst loss and push the chunk
-        if rng.random() >= burst_loss_percent / 100:
+        drop_prob = burst_loss_percent * 0.01
+        if rng.random() >= drop_prob:
             outlet.push_chunk(chunk)
 
         # 3. Calculate sleep duration with impairments


### PR DESCRIPTION
change the np.random.rand to use the rng generator numpy object, so rng.random(). Should've done this before but I missed it I guess.

Also made drop_pob variable to make things clearer.