### PR TITLE
Ensure CLI uses reconstructed receive timestamps

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -207,7 +207,7 @@ def test_measure_records_reconstructed_receive_times(
             zip(src_array.tolist(), per_sample_recv.tolist(), strict=True)
         )
 
-    assert rows == expected_rows
+    assert np.array_equal(rows, expected_rows)
 
 
 def test_measure_json_summary(tmp_path, mock_inlet_worker, mock_compute_metrics):


### PR DESCRIPTION
## Summary
- add a documented helper to rebuild per-sample receive timestamps and reuse it in the metrics pipeline
- update the CLI to skip empty chunks, write reconstructed receive times, and derive latencies from those values
- refresh CLI tests with deterministic fixtures and a regression case for the reconstructed timing data

## Testing
- uv run pytest tests/test_cli.py
- uv run ruff format
- uv run ruff check
