### PR TITLE
Fix cli recording .csv timestamps as chunk times instead of reconstructed timestamps; implement associated regression test

### DIFF
--- a/src/lsl_harness/cli.py
+++ b/src/lsl_harness/cli.py
@@ -178,7 +178,7 @@ def measure(
 
         # Process each chunk of collected samples
         for _data, src_timestamp_list, receive_timestamp in collected_samples:
-            if not src_timestamp_list:
+            if len(src_timestamp_list) == 0:
                 continue
 
             # Convert to ndarray for helper compatibility and numeric stability.


### PR DESCRIPTION
The timestamps in the csv were recorded as chunk timestamps rather than the reconstructed timestamps, so using the csv without running the metrics script would cause confusion due to divergent behavior (that is, metrics using reconstructed but CSV not)

Also implemented a regression test so this behavior doesnt appear again

fixes #37 